### PR TITLE
Change repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ If you would like to show your appreciation for this project, and/or help suppor
 ## Related Links
 
 #### SickRage Website:  
-https://www.sickrage.tv
+http://sickrage.github.io
 
 #### SickRage Project on GitHub:  
-https://github.com/SiCKRAGETV/SickRage
+https://github.com/SickRage/SickRage
 
 -----
 


### PR DESCRIPTION
Quote from miigotu 
`As a team, we have moved from the old org (SiCKRAGETV) to a new org (SickRage), only leaving echelon behind. New org is nearing 2k commits ahead of the old one and is much more stable and maintained, as well as a much larger user base as users have opted to move with the team.
For questions, we are on freenode in #sickrage-issues`
